### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A Model Context Protocol (MCP) server that provides powerful text search capabilities using the `grep` command-line utility. This server allows you to search for patterns in files and directories using both natural language descriptions and direct regex patterns.
 
+<a href="https://glama.ai/mcp/servers/@247arjun/mcp-grep">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@247arjun/mcp-grep/badge" alt="Grep Server MCP server" />
+</a>
+
 ## Features
 
 ### 🧠 Natural Language Search
@@ -343,4 +347,3 @@ echo '{"jsonrpc": "2.0", "method": "initialize", "params": {}}' | node build/ind
 - Blocks potentially dangerous grep flags in advanced mode
 - Input validation with Zod schemas
 - No access to system files outside specified targets
-


### PR DESCRIPTION
This PR adds a badge for the [Grep MCP Server](https://glama.ai/mcp/servers/@247arjun/mcp-grep) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@247arjun/mcp-grep">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@247arjun/mcp-grep/badge" alt="Grep Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.